### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Make conda environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2
         with:
           python-version: 3.9  # Python version to build the html sphinx documentation
           environment-file: devtools/conda-envs/docs_env.yaml  # Path to the documentation conda environment
@@ -33,7 +33,7 @@ jobs:
           auto-activate-base: false
           show-channel-urls: true
       - name: Running the Sphinx to gh-pages Action
-        uses: uibcdf/action-sphinx-docs-to-gh-pages@v1.1.0
+        uses: uibcdf/action-sphinx-docs-to-gh-pages@e8f97e2f34d18fd153f5dc5b1df755d07207d5ee # v1.1.0
         with:
           branch: master
           dir_docs: docs

--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Make conda environment
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/action.yml
+++ b/action.yml
@@ -53,14 +53,18 @@ runs:
       id: to-branch-with-docs
       shell: bash
       run: |
-           git checkout ${{ inputs.branch }}
+           git checkout ${INPUTS_BRANCH}
+      env:
+        INPUTS_BRANCH: ${{ inputs.branch }}
     - name: sphinx html docs compilation
       shell: bash -l {0}      # This is needed to work with conda here. See:https://github.com/marketplace/actions/setup-miniconda#IMPORTANT
       working-directory: ./${{ inputs.dir_docs }}
       run: |
         echo ::group::Sphinx docs compilation
-        sphinx-build -M html . _build ${{ inputs.sphinxopts }}
+        sphinx-build -M html . _build ${INPUTS_SPHINXOPTS}
         echo ::endgroup::
+      env:
+        INPUTS_SPHINXOPTS: ${{ inputs.sphinxopts }}
     - name: pushing to gh-pages
       shell: bash
       run: |
@@ -71,7 +75,7 @@ runs:
             SHA=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.head.sha)
         fi
         SHORT_SHA="$(git rev-parse --short $SHA)"
-        DIR_HTML=${{ inputs.dir_docs }}/_build/html/
+        DIR_HTML=${INPUTS_DIR_DOCS}/_build/html/
         echo "#GitHub Pages" > $DIR_HTML/README.md
         echo "" >> $DIR_HTML/README.md
         echo "Last update of sphinx html documentation from [$SHORT_SHA](https://github.com/$GITHUB_REPOSITORY/tree/$SHA)" >> $DIR_HTML/README.md
@@ -83,6 +87,8 @@ runs:
         echo ::group::Push to gh-pages
         git add -f $DIR_HTML
         git commit -m "From $GITHUB_REF $SHA"
-        git push origin `git subtree split --prefix $DIR_HTML ${{ inputs.branch }}`:gh-pages --force
+        git push origin `git subtree split --prefix $DIR_HTML ${INPUTS_BRANCH}`:gh-pages --force
         echo ::endgroup::
-
+      env:
+        INPUTS_DIR_DOCS: ${{ inputs.dir_docs }}
+        INPUTS_BRANCH: ${{ inputs.branch }}


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
